### PR TITLE
Fixes for issue #46

### DIFF
--- a/AcsListener/AcsListener.Tests/AcsListener.Tests.csproj
+++ b/AcsListener/AcsListener.Tests/AcsListener.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AcsListener.Tests</RootNamespace>
     <AssemblyName>AcsListener.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -19,6 +20,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,24 +40,55 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.3.0.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.3.0\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.5.1\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -79,6 +112,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/AcsListener/AcsListener.Tests/packages.config
+++ b/AcsListener/AcsListener.Tests/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.3.0" targetFramework="net461" />
-  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
-  <package id="System.Console" version="4.0.0" targetFramework="net461" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
-  <package id="System.IO" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.6.0" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net472" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.1" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.1" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net472" />
 </packages>

--- a/AcsListener/AcsListener/AcsListener.csproj
+++ b/AcsListener/AcsListener/AcsListener.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AcsListener</RootNamespace>
     <AssemblyName>AcsListener</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.3.0.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.3.0\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
@@ -47,14 +48,46 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.5.1\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/AcsListener/AcsListener/App.config
+++ b/AcsListener/AcsListener/App.config
@@ -1,11 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+  </startup>
   <appSettings>
-    <add key ="CommandPort" value="13000"/>
-    <add key ="RplUrlPath" value ="http://192.168.9.88/CaptiView/"/>
-    <add key ="AutoReload" value ="true"/>
+    <add key="CommandPort" value="13000"/>
+    <add key="RplUrlPath" value="http://192.168.9.88/CaptiView/"/>
+    <add key="AutoReload" value="true"/>
+    <add key="ClientSettingsProvider.ServiceUri" value=""/>
   </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri=""/>
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400"/>
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/AcsListener/AcsListener/Program.cs
+++ b/AcsListener/AcsListener/Program.cs
@@ -234,9 +234,9 @@ namespace AcsListener
             {
                 // Buffer for reading data
                 Byte[] bytes = new byte[512];
-                String data = null;       // the data received from the listener
+                String data = null; // the data received from the listener
                 String commandInput = ""; // the parsed command received
-                bool listening = true;    // controls the while-loop logic
+                bool listening = true; // controls the while-loop logic
 
                 // Enter the listening loop.
                 while (listening == true)
@@ -263,8 +263,8 @@ namespace AcsListener
                     // Prepare for looping
                     data = null;
                     int i;
-                    bool cancelCommandReceived = false;   // used to control the while-loop logic (and when to quit)
-                    
+                    bool cancelCommandReceived = false; // used to control the while-loop logic (and when to quit)
+
                     // loop to receive all of the data sent by the client
                     while ((cancelCommandReceived == false) && ((i = commandStream.Read(bytes, 0, bytes.Length)) != 0))
                     {
@@ -273,7 +273,7 @@ namespace AcsListener
 
                         if (data == "\u0003") // checking for a CTRL+C from the connected terminal
                         {
-                            cancelCommandReceived = true;   // set boolean logic to exit the while-loop
+                            cancelCommandReceived = true; // set boolean logic to exit the while-loop
                             Log.Information("Received Cancel Command");
                         }
                         else if (data == "\b")
@@ -294,7 +294,7 @@ namespace AcsListener
                                     Log.Information($"Thread #{thread.ManagedThreadId}: CANCEL/QUIT command received - terminating connection");
                                     cancelCommandReceived = true;
                                 }
-                                else  // Begin the section that parses for one of the main commands
+                                else // Begin the section that parses for one of the main commands
                                 {
                                     // List of available commands that we can take:
                                     // HELP   - Shows all of the available commands
@@ -313,8 +313,8 @@ namespace AcsListener
 
                                     var commandSplit = commandInput.Split(' ');
                                     string commandBase = commandSplit[0];
-                                    string commandParameter = ""; 
-                                    String commandOutput = "";  // Any output returned from the processed command
+                                    string commandParameter = "";
+                                    String commandOutput = ""; // Any output returned from the processed command
 
                                     if (commandSplit.Length >= 2) // at least one parameter was passed in with this command - we only accept the first parameter at the moment
                                     {
@@ -344,6 +344,7 @@ namespace AcsListener
                                                     string UrlPath = commandParameter;
                                                     commandOutput = DoCommandLoad(UrlPath);
                                                 }
+
                                                 break;
 
                                             case "STOP":
@@ -361,7 +362,8 @@ namespace AcsListener
                                             case "TIME":
                                                 if (commandParameter == "")
                                                 {
-                                                    commandOutput = "TIME command requires a parameter in format of TIME <parameter>, where parameter is either HH:MM:SS, MM:SS, or MM";
+                                                    commandOutput =
+                                                        "TIME command requires a parameter in format of TIME <parameter>, where parameter is either HH:MM:SS, MM:SS, or MM";
                                                 }
                                                 else
                                                 {
@@ -373,7 +375,7 @@ namespace AcsListener
                                                         if (playoutData.EditRate != "")
                                                         {
                                                             string timeOffsetInput = commandParameter;
-                                                            commandOutput = DoCommandTime(timeOffsetInput, playoutData.EditRate); 
+                                                            commandOutput = DoCommandTime(timeOffsetInput, playoutData.EditRate);
                                                         }
                                                         else
                                                         {
@@ -385,6 +387,7 @@ namespace AcsListener
                                                         commandOutput = "TIME command cannot be used until an RPL is chosen by SELECT";
                                                     }
                                                 }
+
                                                 break;
 
                                             case "LIST":
@@ -442,7 +445,7 @@ namespace AcsListener
                                                             }
                                                         }
                                                     }
-                                                    catch (ArgumentException ex)  // Most likely the PlayoutId supplied does not exist
+                                                    catch (ArgumentException ex) // Most likely the PlayoutId supplied does not exist
                                                     {
                                                         commandOutput = ex.Message;
                                                     }
@@ -454,6 +457,7 @@ namespace AcsListener
                                                     {
                                                     }
                                                 }
+
                                                 break;
 
                                             case "UNLOAD":
@@ -495,7 +499,7 @@ namespace AcsListener
                                                         // potential for the RELOAD action
 
                                                         commandOutput = commandOutput + DoCommandUnload(playoutId);
-                                                        
+
                                                         // commandOutput = "STUB for DoCommandUnload()";
                                                     }
                                                     catch (Exception ex)
@@ -543,7 +547,7 @@ namespace AcsListener
                                     // If the command resulted in any kind of output, then add CRLF to it for proper formatting
                                     if (commandOutput != "")
                                     {
-                                        commandOutput = commandOutput + "\r\n";  // Add a CRLF to the end of the output message so that it is nicely formatted for the other side
+                                        commandOutput = commandOutput + "\r\n"; // Add a CRLF to the end of the output message so that it is nicely formatted for the other side
                                     }
 
                                     // Add a mode status output to the return string being sent to the command connection
@@ -576,6 +580,10 @@ namespace AcsListener
                     listening = false;
                 }
 
+            }
+            catch (ArgumentNullException ex )  // most likely manually thrown by one of the Process methods after encountering an issue with ListenerStream
+            {
+                Log.Error($"[Thread #{thread.ManagedThreadId}]: An Argumenth CommandProcessor: {ex.Message}");
             }
             catch (SocketException e)
             {
@@ -1161,7 +1169,7 @@ namespace AcsListener
                             CanWriteToStream.Reset(); // Disable writing to the ACS NetworkStream for any other thread
 
                             // Close and dispose of the ACS NetworkStream
-                            ListenerStream?.Close(); 
+                            ListenerStream?.Close();
                             ListenerStream?.Dispose();
                         }
                         finally
@@ -1171,11 +1179,11 @@ namespace AcsListener
                     }
 
                     ListenerClient?.Close(); // Close the existing TCP connection
-                    ListenerClient?.Dispose();  
+                    ListenerClient?.Dispose();
                 }
 
                 // Since we have proven it is an ACS talking to us, this will become the new ACS connection
-                ListenerClient = tempTcpClient;  
+                ListenerClient = tempTcpClient;
                 ListenerStream = tempStream;
                 ConnectedToAcs = true; // set the static variable to true to let CommandProcess know if connection has occurred
 
@@ -1246,6 +1254,11 @@ namespace AcsListener
                 Log.Error($"[Thread #{thread.ManagedThreadId}] Error: A NullReferenceException has occurred: {ex.Message}");
                 DoAcsConnectionCleanup();
             }
+            catch (ArgumentNullException ex) // most likely manually thrown when discovering that the ListenerStream is unexpectedly null
+            {
+                Log.Error($"[Thread #{thread.ManagedThreadId}] Error: An ArgumentNullException has occurred: {ex.Message}");
+                DoAcsConnectionCleanup();
+            }
             catch (AcspAnnounceException ex)
             { 
                 // Log the error, but we do not want to abort any pre-existing ACS connection
@@ -1312,7 +1325,7 @@ namespace AcsListener
                     Log.Information($"[Thread #{thread.ManagedThreadId}] Attempting to close the NetworkStream and close the overall ACS TCP connection");
                     CanWriteToStream.WaitOne(1000);
                     CanWriteToStream.Reset();    // Block so that nothing else attempts to write to the stream
-                    ListenerStream.Close();
+                    ListenerStream?.Close();
                 }
                 finally
                 {
@@ -1486,7 +1499,7 @@ namespace AcsListener
             bool announcePairSuccessful = false;
 
             // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-            if (inputStream.DataAvailable is true)
+            if (inputStream?.DataAvailable is true)
             {
                 int clearedBytes = inputStream.ClearStreamForNextMessage();
                 Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -1544,7 +1557,7 @@ namespace AcsListener
                             Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {announceResponse.StatusResponseKeyString}");
                         }
                     }
-                } // end if (ListenerStream.DataAvailable == true) 
+                } // end if (inputStream.DataAvailable == true) 
                 else
                 {
                     Thread.Sleep(100);  // Since there was no data yet, wait 100ms and try again
@@ -1583,7 +1596,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -1594,60 +1607,71 @@ namespace AcsListener
                 CurrentRequestId = leaseRequest.RequestId;
 
                 // Send the GetNewLeaseRequest data packet to the ACS
-                ListenerStream.Write(leaseRequest.PackArray, 0, leaseRequest.PackArray.Length);
-                Log.Information($"[Thread #{thread.ManagedThreadId}, {DateTime.Now}]GetNewLease Request for {leaseSeconds} seconds sent to ACS.  RequestID #: {CurrentRequestId}");
 
-                // Wait for AnnounceResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                // Expecting a GetNewLeaseResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (ListenerStream.DataAvailable == true)
+                    ListenerStream.Write(leaseRequest.PackArray, 0, leaseRequest.PackArray.Length);
+                    Log.Information(
+                        $"[Thread #{thread.ManagedThreadId}, {DateTime.Now}]GetNewLease Request for {leaseSeconds} seconds sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for AnnounceResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Expecting a GetNewLeaseResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader announceResponseHeader = new AcspResponseHeader(header);
-                        if (announceResponseHeader.Key.IsBadRequest)
+                        if (ListenerStream?.DataAvailable == true)
                         {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: GetNewLeaseResponse [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
 
-                        if (announceResponseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good GetNewLeaseResponse received from ACS!");
-
-                            if (announceResponseHeader.Key.NodeNames == Byte13NodeNames.GetNewLeaseResponse)
+                            AcspResponseHeader announceResponseHeader = new AcspResponseHeader(header);
+                            if (announceResponseHeader.Key.IsBadRequest)
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected GetNewLeaseResponse has been received");
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: GetNewLeaseResponse [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
 
-                                int length = announceResponseHeader.PackLength.Length;
+                            if (announceResponseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good GetNewLeaseResponse received from ACS!");
 
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte GetNewLeaseResponse successfully read from network stream");
-
-                                AcspGetNewLeaseResponse leaseResponse = new AcspGetNewLeaseResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {leaseResponse.RequestId}");
-
-                                if (leaseResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                if (announceResponseHeader.Key.NodeNames == Byte13NodeNames.GetNewLeaseResponse)
                                 {
-                                    messagePairSuccessful = true;
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: RrpSuccessful");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {leaseResponse.StatusResponseKeyString}");
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected GetNewLeaseResponse has been received");
+
+                                    int length = announceResponseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information(
+                                        $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte GetNewLeaseResponse successfully read from network stream");
+
+                                    AcspGetNewLeaseResponse leaseResponse = new AcspGetNewLeaseResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {leaseResponse.RequestId}");
+
+                                    if (leaseResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                    {
+                                        messagePairSuccessful = true;
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: RrpSuccessful");
+                                    }
+                                    else
+                                    {
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {leaseResponse.StatusResponseKeyString}");
+                                    }
                                 }
                             }
-                        }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
-
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                }  // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }   
             }  // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set();  // Signal that it is okay to write to the NetworkStream
@@ -1682,7 +1706,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -1693,84 +1717,96 @@ namespace AcsListener
                 CurrentRequestId = statusRequest.RequestId;
 
                 // Send the GetStatusRequest data packet
-                ListenerStream.Write(statusRequest.PackArray, 0, statusRequest.PackArray.Length);
-                Log.Information($"[Thread #{thread.ManagedThreadId}, {DateTime.Now}]GetStatus Request sent to ACS.  RequestID #: {CurrentRequestId}");
-
-                // Wait for GetStatusResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                string debugMessage = "";
-                int messageCounter = 0;
-
-                // Expecting a GetStatusResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (DebugOutput is true)
+                    ListenerStream.Write(statusRequest.PackArray, 0, statusRequest.PackArray.Length);
+                    Log.Information($"[Thread #{thread.ManagedThreadId}, {DateTime.Now}]GetStatus Request sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for GetStatusResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    string debugMessage = "";
+                    int messageCounter = 0;
+
+                    // Expecting a GetStatusResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        string thisMessage = "Debug Info: stopwatch elapsedMs is " + stopwatch.ElapsedMilliseconds + "ms";
-                        if (thisMessage == debugMessage)
+                        if (DebugOutput is true)
                         {
-                            messageCounter++;
-                        }
-                        else
-                        {
-                            if (messageCounter > 0)
+                            string thisMessage = "Debug Info: stopwatch elapsedMs is " + stopwatch.ElapsedMilliseconds + "ms";
+                            if (thisMessage == debugMessage)
                             {
-                                Log.Verbose($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] Debug Info: <previous message repeated {messageCounter} times");
+                                messageCounter++;
                             }
-                            messageCounter = 0;
-                            Log.Verbose($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {thisMessage}");
-                            debugMessage = thisMessage;
-                        }
-                    }
-
-                    if (ListenerStream.DataAvailable == true)
-                    {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader responseHeader = new AcspResponseHeader(header);
-                        if (responseHeader.Key.IsBadRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: GetStatusResponse [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
-
-                        if (responseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good GetStatusResponse received from ACS!");
-
-                            if (responseHeader.Key.NodeNames == Byte13NodeNames.GetStatusResponse)
+                            else
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected GetStatusResponse has been received");
-
-                                int length = responseHeader.PackLength.Length;
-
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte GetStatusResponse successfully read from network stream");
-
-                                AcspGetStatusResponse statusResponse = new AcspGetStatusResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {statusResponse.RequestId}");
-
-                                if (statusResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                if (messageCounter > 0)
                                 {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: RrpSuccessful");
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Message Received: {statusResponse.StatusResponseMessage}");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {statusResponse.StatusResponseKeyString}");
+                                    Log.Verbose($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] Debug Info: <previous message repeated {messageCounter} times");
                                 }
 
-                                messagePairSuccessful = true;
-                                outputMessage = statusResponse.StatusResponseKeyString;
+                                messageCounter = 0;
+                                Log.Verbose($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {thisMessage}");
+                                debugMessage = thisMessage;
                             }
                         }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+
+                        if (ListenerStream?.DataAvailable == true)
+                        {
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
+
+                            AcspResponseHeader responseHeader = new AcspResponseHeader(header);
+                            if (responseHeader.Key.IsBadRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: GetStatusResponse [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
+
+                            if (responseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good GetStatusResponse received from ACS!");
+
+                                if (responseHeader.Key.NodeNames == Byte13NodeNames.GetStatusResponse)
+                                {
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected GetStatusResponse has been received");
+
+                                    int length = responseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information(
+                                        $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte GetStatusResponse successfully read from network stream");
+
+                                    AcspGetStatusResponse statusResponse = new AcspGetStatusResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {statusResponse.RequestId}");
+
+                                    if (statusResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                    {
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: RrpSuccessful");
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Message Received: {statusResponse.StatusResponseMessage}");
+                                    }
+                                    else
+                                    {
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {statusResponse.StatusResponseKeyString}");
+                                    }
+
+                                    messagePairSuccessful = true;
+                                    outputMessage = statusResponse.StatusResponseKeyString;
+                                }
+                            }
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                } // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }
             } // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set();  // Set signal to indicate that it is safe to write to the NetworkStream
@@ -1803,7 +1839,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -1814,60 +1850,73 @@ namespace AcsListener
                 CurrentRequestId = rplRequest.RequestId;
 
                 // Send the SetRplLocationRequest data packet to the ACS
-                ListenerStream.Write(rplRequest.PackArray, 0, rplRequest.PackArray.Length);
-                Log.Information($"[{DateTime.Now}]SetRplLocation Request sent to ACS.  RequestID #: {CurrentRequestId}");
-
-                // Wait for SetRplLocationResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                // Expecting a GetStatusResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (ListenerStream.DataAvailable == true)
+                    ListenerStream.Write(rplRequest.PackArray, 0, rplRequest.PackArray.Length);
+                    Log.Information($"[{DateTime.Now}]SetRplLocation Request sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for SetRplLocationResponse from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Expecting a GetStatusResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader responseHeader = new AcspResponseHeader(header);
-                        if (responseHeader.Key.IsBadRequest)
+                        if (ListenerStream?.DataAvailable == true)
                         {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: SetRplLocation [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}] {numberOfBytes}-byte header successfully read from network stream");
 
-                        if (responseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good SetRplLocationResponse received from ACS!");
-
-                            if (responseHeader.Key.NodeNames == Byte13NodeNames.SetRplLocationResponse)
+                            AcspResponseHeader responseHeader = new AcspResponseHeader(header);
+                            if (responseHeader.Key.IsBadRequest)
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected SetRplLocationResponse has been received");
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: SetRplLocation [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
 
-                                int length = responseHeader.PackLength.Length;
+                            if (responseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Good SetRplLocationResponse received from ACS!");
 
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information( $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte SetRplLocationResponse successfully read from network stream");
-
-                                AcspSetRplLocationResponse locationResponse = new AcspSetRplLocationResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {locationResponse.RequestId}");
-
-                                if ((locationResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful) || (locationResponse.StatusResponseKey == GeneralStatusResponseKey.Processing))
+                                if (responseHeader.Key.NodeNames == Byte13NodeNames.SetRplLocationResponse)
                                 {
-                                    messagePairSuccessful = true;
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {locationResponse.StatusResponseKeyString}");
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Message Received: {locationResponse.StatusResponseMessage}");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {locationResponse.StatusResponseKeyString}");
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Expected SetRplLocationResponse has been received");
+
+                                    int length = responseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information(
+                                        $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {numberOfBytes}-byte SetRplLocationResponse successfully read from network stream");
+
+                                    AcspSetRplLocationResponse locationResponse = new AcspSetRplLocationResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: RequestId is: {locationResponse.RequestId}");
+
+                                    if ((locationResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful) ||
+                                        (locationResponse.StatusResponseKey == GeneralStatusResponseKey.Processing))
+                                    {
+                                        messagePairSuccessful = true;
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {locationResponse.StatusResponseKeyString}");
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Message Received: {locationResponse.StatusResponseMessage}");
+                                    }
+                                    else
+                                    {
+                                        Log.Information(
+                                            $"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Response Received: {locationResponse.StatusResponseKeyString}");
+                                    }
                                 }
                             }
-                        }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                } // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }
             } // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set();
@@ -1898,7 +1947,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -1909,60 +1958,68 @@ namespace AcsListener
                 CurrentRequestId = outputModeRequest.RequestId;
 
                 // Send the SetOutputModeRequest data packet to the ACS
-                ListenerStream.Write(outputModeRequest.PackArray, 0, outputModeRequest.PackArray.Length);
-                Log.Information($"[{DateTime.Now}]SetOutputMode Request sent to ACS.  RequestID #: {CurrentRequestId}");
-
-                // Wait for SetOutputMode Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                // Expecting a GetStatusResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (ListenerStream.DataAvailable == true)
+                    ListenerStream.Write(outputModeRequest.PackArray, 0, outputModeRequest.PackArray.Length);
+                    Log.Information($"[{DateTime.Now}]SetOutputMode Request sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for SetOutputMode Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Expecting a GetStatusResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader responseHeader = new AcspResponseHeader(header);
-                        if (responseHeader.Key.IsBadRequest)
+                        if (ListenerStream?.DataAvailable == true)
                         {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: SetOutputMode Response [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
 
-                        if (responseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: Good SetOutputMode Response received from ACS!");
-
-                            if (responseHeader.Key.NodeNames == Byte13NodeNames.SetOutputModeResponse)
+                            AcspResponseHeader responseHeader = new AcspResponseHeader(header);
+                            if (responseHeader.Key.IsBadRequest)
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected SetOutputModeResponse has been received");
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: SetOutputMode Response [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
 
-                                int length = responseHeader.PackLength.Length;
+                            if (responseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Good SetOutputMode Response received from ACS!");
 
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte SetRplLocationResponse successfully read from network stream");
-
-                                AcspSetOutputModeResponse outputModeResponse = new AcspSetOutputModeResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {outputModeResponse.RequestId}");
-
-                                if (outputModeResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                if (responseHeader.Key.NodeNames == Byte13NodeNames.SetOutputModeResponse)
                                 {
-                                    messagePairSuccessful = true;
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {outputModeResponse.StatusResponseKeyString}");
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {outputModeResponse.StatusResponseMessage}");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {outputModeResponse.StatusResponseKeyString}");
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected SetOutputModeResponse has been received");
+
+                                    int length = responseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte SetRplLocationResponse successfully read from network stream");
+
+                                    AcspSetOutputModeResponse outputModeResponse = new AcspSetOutputModeResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {outputModeResponse.RequestId}");
+
+                                    if (outputModeResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                    {
+                                        messagePairSuccessful = true;
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {outputModeResponse.StatusResponseKeyString}");
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {outputModeResponse.StatusResponseMessage}");
+                                    }
+                                    else
+                                    {
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {outputModeResponse.StatusResponseKeyString}");
+                                    }
                                 }
                             }
-                        }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                } // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }
             } // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set();  // Signal that it is okay to write to the NetworkStream again
@@ -1993,7 +2050,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -2004,60 +2061,68 @@ namespace AcsListener
                 CurrentRequestId = updateTimelineRequest.RequestId;
 
                 // Send the UpdateTimelineRequest data packet to the ACS
-                ListenerStream.Write(updateTimelineRequest.PackArray, 0, updateTimelineRequest.PackArray.Length);
-                Log.Information($"[{DateTime.Now}]UpdateTimeline Request sent to ACS.  RequestID #: {CurrentRequestId}");
-
-                // Wait for UpdateTimeline Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                // Expecting a GetStatusResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (ListenerStream.DataAvailable == true)
+                    ListenerStream.Write(updateTimelineRequest.PackArray, 0, updateTimelineRequest.PackArray.Length);
+                    Log.Information($"[{DateTime.Now}]UpdateTimeline Request sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for UpdateTimeline Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Expecting a GetStatusResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader responseHeader = new AcspResponseHeader(header);
-                        if (responseHeader.Key.IsBadRequest)
+                        if (ListenerStream?.DataAvailable == true)
                         {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: UpdateTimeline Response [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
 
-                        if (responseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: Good UpdateTimeline Response received from ACS!");
-
-                            if (responseHeader.Key.NodeNames == Byte13NodeNames.UpdateTimelineResponse)
+                            AcspResponseHeader responseHeader = new AcspResponseHeader(header);
+                            if (responseHeader.Key.IsBadRequest)
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected UpdateTimelineResponse has been received");
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: UpdateTimeline Response [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
 
-                                int length = responseHeader.PackLength.Length;
+                            if (responseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Good UpdateTimeline Response received from ACS!");
 
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte UpdateTimelineResponse successfully read from network stream");
-
-                                AcspUpdateTimelineResponse updateTimelineResponse = new AcspUpdateTimelineResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {updateTimelineResponse.RequestId}");
-
-                                if (updateTimelineResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                if (responseHeader.Key.NodeNames == Byte13NodeNames.UpdateTimelineResponse)
                                 {
-                                    messagePairSuccessful = true;
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {updateTimelineResponse.StatusResponseKeyString}");
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {updateTimelineResponse.StatusResponseMessage}");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {updateTimelineResponse.StatusResponseKeyString}");
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected UpdateTimelineResponse has been received");
+
+                                    int length = responseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte UpdateTimelineResponse successfully read from network stream");
+
+                                    AcspUpdateTimelineResponse updateTimelineResponse = new AcspUpdateTimelineResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {updateTimelineResponse.RequestId}");
+
+                                    if (updateTimelineResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                    {
+                                        messagePairSuccessful = true;
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {updateTimelineResponse.StatusResponseKeyString}");
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {updateTimelineResponse.StatusResponseMessage}");
+                                    }
+                                    else
+                                    {
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {updateTimelineResponse.StatusResponseKeyString}");
+                                    }
                                 }
                             }
-                        }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                } // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }
             } // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set(); // Signal that it is okay to write to the NetworkStream again
@@ -2088,7 +2153,7 @@ namespace AcsListener
             while (messagePairSuccessful == false)
             {
                 // Check to see if there is any unexpected data in the stream, and if so, purge it prior to sending the request
-                if (ListenerStream.DataAvailable is true)
+                if (ListenerStream?.DataAvailable is true)
                 {
                     int clearedBytes = ListenerStream.ClearStreamForNextMessage();
                     Log.Debug($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: {clearedBytes} bytes of additional data cleared from the stream");
@@ -2099,60 +2164,68 @@ namespace AcsListener
                 CurrentRequestId = terminateLeaseRequest.RequestId;
 
                 // Send the TerminateLeaseRequest data packet to the ACS
-                ListenerStream.Write(terminateLeaseRequest.PackArray, 0, terminateLeaseRequest.PackArray.Length);
-                Log.Information($"[{DateTime.Now}]TerminateLease Request sent to ACS.  RequestID #: {CurrentRequestId}");
-
-                // Wait for TerminateLease Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
-
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-                // Expecting a TerminateLeaseResponse message
-                while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
+                if (ListenerStream != null)
                 {
-                    if (ListenerStream.DataAvailable == true)
+                    ListenerStream.Write(terminateLeaseRequest.PackArray, 0, terminateLeaseRequest.PackArray.Length);
+                    Log.Information($"[{DateTime.Now}]TerminateLease Request sent to ACS.  RequestID #: {CurrentRequestId}");
+
+                    // Wait for TerminateLease Response from ACS (Per SMPTE 430-10:2010, must wait at least 2 seconds before allowing timeout)
+
+                    Stopwatch stopwatch = new Stopwatch();
+                    stopwatch.Start();
+
+                    // Expecting a TerminateLeaseResponse message
+                    while (messagePairSuccessful == false && (stopwatch.ElapsedMilliseconds < timeoutValue))
                     {
-                        numberOfBytes = ListenerStream.Read(header, 0, header.Length);  // Read 20-byte header in from the NetworkStream
-                        Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
-
-                        AcspResponseHeader responseHeader = new AcspResponseHeader(header);
-                        if (responseHeader.Key.IsBadRequest)
+                        if (ListenerStream?.DataAvailable == true)
                         {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: TerminateLease Response [Bad Message] received from ACS!");
-                            // Need some control logic here to figure out how to handle a Bad Request message
-                        }
+                            numberOfBytes = ListenerStream.Read(header, 0, header.Length); // Read 20-byte header in from the NetworkStream
+                            Log.Information($"[Thread #{thread.ManagedThreadId}] {numberOfBytes}-byte header successfully read from network stream");
 
-                        if (responseHeader.Key.IsGoodRequest)
-                        {
-                            Log.Information($"[Thread #{thread.ManagedThreadId}]: Good TerminateLease Response received from ACS!");
-
-                            if (responseHeader.Key.NodeNames == Byte13NodeNames.TerminateLeaseResponse)
+                            AcspResponseHeader responseHeader = new AcspResponseHeader(header);
+                            if (responseHeader.Key.IsBadRequest)
                             {
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected TerminateLeaseResponse has been received");
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: TerminateLease Response [Bad Message] received from ACS!");
+                                // Need some control logic here to figure out how to handle a Bad Request message
+                            }
 
-                                int length = responseHeader.PackLength.Length;
+                            if (responseHeader.Key.IsGoodRequest)
+                            {
+                                Log.Information($"[Thread #{thread.ManagedThreadId}]: Good TerminateLease Response received from ACS!");
 
-                                Byte[] bytes = new Byte[length];
-                                numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte TerminateLeaseResponse successfully read from network stream");
-
-                                AcspTerminateLeaseResponse terminateLeaseResponse = new AcspTerminateLeaseResponse(bytes);
-                                Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {terminateLeaseResponse.RequestId}");
-
-                                if (terminateLeaseResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                if (responseHeader.Key.NodeNames == Byte13NodeNames.TerminateLeaseResponse)
                                 {
-                                    messagePairSuccessful = true;
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {terminateLeaseResponse.StatusResponseKeyString}");
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {terminateLeaseResponse.StatusResponseMessage}");
-                                }
-                                else
-                                {
-                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {terminateLeaseResponse.StatusResponseKeyString}");
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: Expected TerminateLeaseResponse has been received");
+
+                                    int length = responseHeader.PackLength.Length;
+
+                                    Byte[] bytes = new Byte[length];
+                                    numberOfBytes = ListenerStream.Read(bytes, 0, bytes.Length); // Read variable-length header in from NetworkStream
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: {numberOfBytes}-byte TerminateLeaseResponse successfully read from network stream");
+
+                                    AcspTerminateLeaseResponse terminateLeaseResponse = new AcspTerminateLeaseResponse(bytes);
+                                    Log.Information($"[Thread #{thread.ManagedThreadId}]: RequestId is: {terminateLeaseResponse.RequestId}");
+
+                                    if (terminateLeaseResponse.StatusResponseKey == GeneralStatusResponseKey.RrpSuccessful)
+                                    {
+                                        messagePairSuccessful = true;
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {terminateLeaseResponse.StatusResponseKeyString}");
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Message Received: {terminateLeaseResponse.StatusResponseMessage}");
+                                    }
+                                    else
+                                    {
+                                        Log.Information($"[Thread #{thread.ManagedThreadId}]: Response Received: {terminateLeaseResponse.StatusResponseKeyString}");
+                                    }
                                 }
                             }
-                        }
-                    }  // if (ListenerStream.DataAvailable == true)
-                }  // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                        } // if (ListenerStream.DataAvailable == true)
+                    } // end while(stopwatch.ElapsedMilliseconds < timeoutValue)
+                } // if (ListenerStream != null)
+                else  // if we reach this point then we need to force a NullReferenceException to be caught further up the stack
+                {
+                    Log.Error($"[Thread #{thread.ManagedThreadId}, RequestID #{CurrentRequestId}]: Error encountered with the ACS network stream");
+                    throw new ArgumentNullException(nameof(ListenerStream), $"The ListenerStream object is null when it should be set");
+                }
             } // end while(messagePairSuccessful == false)
 
             CanWriteToStream.Set();     // The subsequent clean-up activity needs the signal set (as it safely waits for any other ACS write to finish first)

--- a/AcsListener/AcsListener/packages.config
+++ b/AcsListener/AcsListener/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.3.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.6.0" targetFramework="net472" />
   <package id="Serilog" version="2.8.0" targetFramework="net461" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net461" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net461" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
-  <package id="System.Console" version="4.0.0" targetFramework="net461" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
-  <package id="System.IO" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.1" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.1" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net472" />
 </packages>

--- a/AcsListener/RplCreator/App.config
+++ b/AcsListener/RplCreator/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/AcsListener/RplCreator/RplCreator.csproj
+++ b/AcsListener/RplCreator/RplCreator.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>RplCreator</RootNamespace>
     <AssemblyName>RplCreator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.3.0.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.3.0\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
@@ -46,13 +47,44 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.5.1\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/AcsListener/RplCreator/packages.config
+++ b/AcsListener/RplCreator/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.3.0" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.6.0" targetFramework="net472" />
   <package id="Serilog" version="2.8.0" targetFramework="net461" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net461" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net461" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
-  <package id="System.Console" version="4.0.0" targetFramework="net461" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
-  <package id="System.IO" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0" targetFramework="net461" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.1" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.1" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net472" />
 </packages>

--- a/AcsListener/RplCreatorTests/RplCreatorTests.csproj
+++ b/AcsListener/RplCreatorTests/RplCreatorTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RplCreatorTests</RootNamespace>
     <AssemblyName>RplCreatorTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -19,6 +20,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,10 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -50,9 +52,6 @@
   <ItemGroup>
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RplCreator\RplCreator.csproj">
@@ -64,6 +63,9 @@
       <Name>SharedCommon</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -72,6 +74,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/AcsListener/RplCreatorTests/packages.config
+++ b/AcsListener/RplCreatorTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net472" />
 </packages>

--- a/AcsListener/SharedCommon/SharedCommon.csproj
+++ b/AcsListener/SharedCommon/SharedCommon.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharedCommon</RootNamespace>
     <AssemblyName>SharedCommon</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Fixes #46

I've added code throughout all of the Process* methods to handle a situation where ListenerStream is null. I perform a null check right before the ListenerStream.Write call (sending the outgoing message request), and if it fails the null check, then I throw a ArgumentNullException (true, its not really an "argument", its a static variable - but this is the exception that applies). As a result of this exception, I put corresponding catch statement for it in both ListenerProcess and CommandProcess.

Also, as part of the work effort, I upgraded my projects to .Net framework 4.7.2, and upgraded all of my 3rd party NuGet packages to support that as well.